### PR TITLE
feat: add AI / Local LLM scan category

### DIFF
--- a/spoonmap.py
+++ b/spoonmap.py
@@ -1155,6 +1155,11 @@ EXTERNAL_SENSITIVE_PORTS = [
     ('61616', 'HIGH',     'ActiveMQ — message broker should not be internet-facing'),
     ('8009',  'HIGH',     'AJP Connector — Tomcat AJP should never be internet-facing (CVE-2020-1938)'),
     ('6000',  'HIGH',     'X11 Display — remote X11 access allows keystroke/screen capture'),
+    ('11434', 'HIGH',     'Ollama — local LLM API; unauthenticated by default, should not be internet-facing'),
+    ('1234',  'HIGH',     'LM Studio — local LLM API; unauthenticated by default, should not be internet-facing'),
+    ('7860',  'HIGH',     'text-generation-webui (Gradio) — LLM UI; no auth by default, should not be internet-facing'),
+    ('5001',  'HIGH',     'KoboldCpp — local LLM API; no auth by default, should not be internet-facing'),
+    ('1337',  'HIGH',     'Jan — local LLM API; no auth by default, should not be internet-facing'),
 ]
 
 SERVICE_CATEGORIES = {
@@ -1187,6 +1192,9 @@ SERVICE_CATEGORIES = {
     ],
     'Containers & Debuggers': [
         '2377', '10250', '8001', '9229', '2345', '5005', '61616', '8009', '6000'
+    ],
+    'AI / Local LLM': [
+        '11434', '1234', '7860', '5000', '5001', '1337', '3000', '8000', '8080',
     ],
 }
 


### PR DESCRIPTION
Closes #14

## Summary

- New `AI / Local LLM` entry in `SERVICE_CATEGORIES` covering 9 ports used by Ollama, LM Studio, llama.cpp, text-generation-webui, vLLM, Jan, Open WebUI, KoboldCpp, and Tabby
- Five uniquely-AI ports (`11434`, `1234`, `7860`, `5001`, `1337`) added to `EXTERNAL_SENSITIVE_PORTS` at `HIGH` severity; ports already covered by existing `Web` findings rules (`8000`, `8080`, `5000`, `3000`) were not duplicated

## Test plan

- [ ] `uv run pytest tests/` — all existing tests pass
- [ ] `AI / Local LLM` appears in the interactive category selection prompt
- [ ] `scan_categories: ["AI / Local LLM"]` in `config.json` targets the correct ports
- [ ] `findings.txt` flags `11434`, `1234`, `7860`, `5001`, and `1337` as `HIGH` on an external scan result

🤖 Generated with [Claude Code](https://claude.com/claude-code)