### PR TITLE
fix: skip empty result XML when aggregating scan output

### DIFF
--- a/spoonmap.py
+++ b/spoonmap.py
@@ -3756,6 +3756,53 @@ def _merge_host_xml(base, other):
                 seen_scripts.add(script.get('id'))
 
 
+def _parse_result_xml(path):
+    """Parse one masscan/nmap result file, returning None if it holds no results.
+
+    A zero-length file is the normal on-disk form of a batch that found nothing:
+    _run_masscan_batch() returns {} for an empty -oX file rather than treating it
+    as an error, so a scan where any batch came up dry leaves empty XML behind.
+    A killed nmap or masscan can likewise leave an unterminated file. Callers
+    aggregating a whole results directory must skip both instead of aborting.
+    """
+    if not path.endswith('.xml') or not os.path.isfile(path) or os.path.getsize(path) == 0:
+        return None
+    try:
+        return etree.parse(path)
+    except etree.ParseError as e:
+        print(_COLOR_ERROR + f'Warning: skipping unreadable result file '
+              f'{os.path.basename(path)}: {e}' + _COLOR_RESET)
+        return None
+
+
+def _aggregate_result_dir(result_dir, ip_to_hostname):
+    """Merge every result file in *result_dir* into (hosts_json, xml_hosts).
+
+    Returns the JSON-shaped host list and an {ip: merged <host> Element} map,
+    deduplicating hosts seen in more than one file.
+    """
+    hosts_json = []
+    ip_index   = {}  # {ip: index into hosts_json}
+    xml_hosts  = {}  # {ip: merged <host> Element}
+    for xml_file in sorted(os.listdir(result_dir)):
+        root = _parse_result_xml(os.path.join(result_dir, xml_file))
+        if root is None:
+            continue
+        for host in root.findall('host'):
+            hd = _host_elem_to_dict(host, ip_to_hostname)
+            ip = hd['ip']
+            if ip in xml_hosts:
+                _merge_host_xml(xml_hosts[ip], host)
+                existing = hosts_json[ip_index[ip]]
+                existing['ports'].extend(hd['ports'])
+                existing['hostscripts'].update(hd['hostscripts'])
+            else:
+                xml_hosts[ip] = host
+                ip_index[ip] = len(hosts_json)
+                hosts_json.append(hd)
+    return hosts_json, xml_hosts
+
+
 def _cleanup_cmd(dir_path):
     """Handle --cleanup: remove prior scan output from output_path and exit."""
     idx = sys.argv.index('--cleanup')
@@ -4668,23 +4715,7 @@ def main():  # pragma: no cover -- interactive CLI entry point; orchestrates
                 result_dir = f'{output_path}/nmap_results/'
             else:
                 result_dir = f'{disc}/masscan_results/'
-            hosts_json = []
-            ip_index   = {}  # {ip: index into hosts_json}
-            xml_hosts  = {}  # {ip: merged <host> Element}
-            for xml_file in sorted(os.listdir(result_dir)):
-                root = etree.parse(result_dir + xml_file)
-                for host in root.findall('host'):
-                    hd = _host_elem_to_dict(host, ip_to_hostname)
-                    ip = hd['ip']
-                    if ip in xml_hosts:
-                        _merge_host_xml(xml_hosts[ip], host)
-                        existing = hosts_json[ip_index[ip]]
-                        existing['ports'].extend(hd['ports'])
-                        existing['hostscripts'].update(hd['hostscripts'])
-                    else:
-                        xml_hosts[ip] = host
-                        ip_index[ip] = len(hosts_json)
-                        hosts_json.append(hd)
+            hosts_json, xml_hosts = _aggregate_result_dir(result_dir, ip_to_hostname)
             xml_result = '<?xml version="1.0"?>\n<!-- SpooNMAP -->\n<nmaprun>\n'
             for host_elem in xml_hosts.values():
                 xml_result += etree.tostring(host_elem, encoding="unicode", method="xml")

--- a/tests/test_spoonmap.py
+++ b/tests/test_spoonmap.py
@@ -70,6 +70,8 @@ from spoonmap import (
     _nmap_udp_discovery,
     _parse_masscan_ping_xml,
     _parse_nmap_sn_xml,
+    _parse_result_xml,
+    _aggregate_result_dir,
     _path_completion,
     _run_masscan_batch,
     _scan_extra_sql_ports,
@@ -5268,6 +5270,92 @@ class TestParseNmapSnXml:
         f = tmp_path / 'sn.xml'
         f.write_text('<nmaprun><host>')  # unclosed tags
         assert _parse_nmap_sn_xml(str(f)) == set()
+
+
+# ── TestParseResultXml ────────────────────────────────────────────────────────
+
+def _result_xml(*ips):
+    hosts = ''.join(
+        f'<host><address addr="{ip}" addrtype="ipv4"/>'
+        f'<ports><port protocol="tcp" portid="445"><state state="open"/></port></ports>'
+        '</host>'
+        for ip in ips
+    )
+    return f'<?xml version="1.0"?><nmaprun>{hosts}</nmaprun>'
+
+
+class TestParseResultXml:
+    """_parse_result_xml() skips files that carry no parseable results."""
+
+    def test_parses_valid_file(self, tmp_path):
+        f = tmp_path / 'batch_0.xml'
+        f.write_text(_result_xml('10.0.0.1'))
+        root = _parse_result_xml(str(f))
+        assert [h.find('address').attrib['addr'] for h in root.findall('host')] == ['10.0.0.1']
+
+    def test_empty_file_returns_none(self, tmp_path):
+        # A zero-length -oX file is how masscan records a batch with no open
+        # ports; _run_masscan_batch() returns {} for it rather than erroring.
+        f = tmp_path / 'batch_0.xml'
+        f.write_text('')
+        assert _parse_result_xml(str(f)) is None
+
+    def test_truncated_file_returns_none(self, tmp_path):
+        # A killed nmap leaves the prologue with no closing </nmaprun>.
+        f = tmp_path / 'port443.xml'
+        f.write_text('<?xml version="1.0"?>\n<nmaprun><host>')
+        assert _parse_result_xml(str(f)) is None
+
+    def test_non_xml_file_returns_none(self, tmp_path):
+        f = tmp_path / 'batch_0.txt'
+        f.write_text('not xml at all')
+        assert _parse_result_xml(str(f)) is None
+
+    def test_directory_returns_none(self, tmp_path):
+        d = tmp_path / 'nested.xml'
+        d.mkdir()
+        assert _parse_result_xml(str(d)) is None
+
+    def test_missing_file_returns_none(self, tmp_path):
+        assert _parse_result_xml(str(tmp_path / 'nope.xml')) is None
+
+
+class TestAggregateResultDir:
+    """_aggregate_result_dir() must survive empty result files (regression)."""
+
+    def test_empty_batch_files_are_skipped(self, tmp_path):
+        # Mirrors the real failure: masscan_results/ where batch_0.xml sorts
+        # first and is empty, which used to abort the whole run with
+        # "ParseError: no element found: line 1, column 0".
+        for idx in range(3):
+            (tmp_path / f'batch_{idx}.xml').write_text('')
+        (tmp_path / 'batch_3.xml').write_text(_result_xml('10.0.0.7'))
+
+        hosts_json, xml_hosts = _aggregate_result_dir(str(tmp_path), {})
+
+        assert list(xml_hosts) == ['10.0.0.7']
+        assert [h['ip'] for h in hosts_json] == ['10.0.0.7']
+
+    def test_all_files_empty_yields_nothing(self, tmp_path):
+        (tmp_path / 'batch_0.xml').write_text('')
+        assert _aggregate_result_dir(str(tmp_path), {}) == ([], {})
+
+    def test_merges_same_ip_across_files(self, tmp_path):
+        (tmp_path / 'batch_0.xml').write_text('')
+        (tmp_path / 'port22.xml').write_text(_result_xml('10.0.0.1'))
+        (tmp_path / 'port80.xml').write_text(_result_xml('10.0.0.1', '10.0.0.2'))
+
+        hosts_json, xml_hosts = _aggregate_result_dir(str(tmp_path), {})
+
+        assert sorted(xml_hosts) == ['10.0.0.1', '10.0.0.2']
+        merged = next(h for h in hosts_json if h['ip'] == '10.0.0.1')
+        assert len(merged['ports']) == 2
+
+    def test_trailing_slash_result_dir(self, tmp_path):
+        # main() builds result_dir with a trailing separator.
+        (tmp_path / 'batch_0.xml').write_text(_result_xml('10.0.0.5'))
+        _, xml_hosts = _aggregate_result_dir(str(tmp_path) + os.sep, {})
+        assert list(xml_hosts) == ['10.0.0.5']
 
 
 # ── TestRunMasscanBatchWaitMinimum ─────────────────────────────────────────────


### PR DESCRIPTION
Fixes #18.

## Problem

`main()`'s final aggregation loop parsed every file in the results directory with no size check and no `ParseError` guard, so one empty file aborted the whole run:

```
File "./spoonmap.py", line 4675, in main
    root = etree.parse(result_dir + xml_file)
xml.etree.ElementTree.ParseError: no element found: line 1, column 0
```

That happens after all scanning has completed but before `spoonmap_output.xml`, `.json`, and findings are written, so the run's entire output is lost.

An empty file isn't corruption — it's the normal on-disk form of a batch that found nothing. `_run_masscan_batch()` returns `{}` for a zero-length `-oX` file, which is exactly how `mass_scan()` decides to print `No hosts found in batch N/M`. So any port-scan-only run where a batch came up dry leaves an empty `batch_N.xml` behind, and since `batch_0.xml` sorts first, aggregation crashed on its very first file. The file also persisted across runs, because the resume gate checks only existence and mtime, so every retry hit the same crash.

## Change

Two new helpers, and `main()`'s inline loop becomes a single call:

- `_parse_result_xml(path)` returns `None` for anything that can't yield results — non-`.xml` entries, directories, zero-length files, and unparseable ones (a killed nmap leaves an unterminated file). It warns only on the unparseable case, since an empty file is expected and shouldn't generate noise.
- `_aggregate_result_dir(result_dir, ip_to_hostname)` walks the directory through that helper and skips whatever comes back `None`.

This matches the guards the module's four other parse sites already have (`generate_findings`, `_count_unmatched_service_ports`, `_validate_snmp_any_community`, `_filter_udp_live_hosts`). The merge and dedup logic is unchanged; extracting it into a function is what makes the real code path testable rather than a test that merely mirrors it.

Deliberately **not** excluded from aggregation: `probe_fast*.xml` / `probe_slow*.xml`. Those look like scratch files, but when the calibration probe finds hosts those ports aren't re-queued into the main batch phase (`ports_to_batch = remaining_ports`), so the probe XML is the only XML record of them. Skipping them would silently drop hosts; there's a test covering this.

## Verification

Replicated a real failing scan directory — 17 empty `batch_N.xml` plus an empty `portFull.xml`, plus genuine output in `probe_fast.xml` and `batch_17.xml`. The old code reproduces the traceback verbatim on `batch_0.xml`; the new code parses cleanly and returns both hosts.

Full suite: **659 passed, coverage 99.27%** (95% gate). Ten new tests in `TestParseResultXml` and `TestAggregateResultDir` cover the empty, truncated, non-XML, directory, and missing-file cases, plus the regression itself and cross-file IP merging.

Three failures are pre-existing on `main` and untouched by this change (`TestOpenvpnDetectNseUdp::test_detects_openvpn_server_v2` and two `TestNmapPortDiscovery` resume tests) — filed separately as #21.

## Related

This fixes the crash but not the underlying fragility, filed separately: #19 (resume gates trust existence/mtime rather than content, so a truncated result file is permanently cached) and #20 (nmap failures are invisible — exit status discarded, stderr to `DEVNULL`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)