### PR TITLE
Add greppable output (spoonmap_output.gnmap)

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,14 +297,31 @@ Inter-scan wait: 29s (target ~256 hosts)
     masscan_results/portN.xml   # raw masscan XML per port (masscan port discovery path)
     live_hosts/portN.txt        # deduplicated IPs per port
   nmap_results/portN.xml        # nmap banner (-sV) XML per port
+  nmap_results/portN.gnmap      # nmap greppable (-oG) output per port
   nse_results/portN.xml         # nmap NSE script XML per port (script_scan only)
   all_live_hosts.txt            # union of all live IPs
   spoonmap_output.xml           # merged nmap XML (or masscan if no banner scan)
   spoonmap_output.json          # same data as JSON — list of host objects by IP
+  spoonmap_output.gnmap         # merged greppable output, one line per host (banner scan only)
   findings.txt                  # severity-sorted findings report (script_scan only)
   findings.md                   # same report in Markdown table format
   findings.json                 # same report as a JSON array (script_scan only)
 ```
+
+### Greppable output
+
+`spoonmap_output.gnmap` is nmap's grepable format — one line per host — merged across every port scanned in the banner pass:
+
+```
+# SpooNMAP aggregated greppable output
+Host: 10.0.0.5 (web01)	Ports: 22/open/tcp//ssh//OpenSSH 8.9p1/, 80/open/tcp//http//nginx 1.18/
+Host: 10.0.0.200 ()	Ports: 445/open/tcp//microsoft-ds///
+# SpooNMAP done: 2 hosts
+```
+
+Because each port is scanned by its own nmap invocation, nmap writes one `nmap_results/portN.gnmap` per port and SpooNMAP merges them, so a host open on three ports is one line with three port entries rather than three lines — matching how `spoonmap_output.xml`/`.json` merge the same hosts, and keeping line counts usable as host counts. Hosts are in numeric IP order and port entries in numeric port order, so the file is stable across runs and diffable between scans.
+
+Written for the banner scan only; a masscan-only run (`banner_scan` off) produces no grepable output. If a port has nmap XML but no `.gnmap` — a scan resumed from before this output existed — those ports are named in a warning rather than silently dropped from the aggregate.
 
 `spoonmap_output.json` consolidates hosts across all per-port files, merging ports for the same IP:
 

--- a/spoonmap.py
+++ b/spoonmap.py
@@ -1242,7 +1242,7 @@ def _fname_port(stem: str) -> str:
 # Result dirs and files written during a scan run.
 _RESULT_DIRS  = ('discovery', 'nmap_results', 'nse_results', 'live_hosts')
 _RESULT_FILES = ('all_live_hosts.txt', 'spoonmap_output.xml',
-                 'spoonmap_output.json',
+                 'spoonmap_output.json', 'spoonmap_output.gnmap',
                  'findings.txt', 'findings.md', 'findings.json')
 
 
@@ -2066,8 +2066,19 @@ def _build_nmap_cmd(dest_port, input_file, output_file, source_port,
         if source_port and not (script_scan and dest_port in _MULTI_SCRIPT_PORTS):
             cmd += ['--source-port', source_port]
 
-    cmd += ['-iL', input_file, '-oX', output_file]
+    # Greppable output alongside the XML, one file per port so that each has a
+    # single writer.  nmap_scan() runs several workers concurrently, so a shared
+    # -oG target with --append-output would interleave their writes into a
+    # plausible-looking but corrupt host list.  Banner pass only: the script pass
+    # writes to its own directory and its results are surfaced as findings.
+    cmd += ['-iL', input_file, '-oX', output_file,
+            '-oG', _gnmap_path(output_file)]
     return cmd
+
+
+def _gnmap_path(xml_path):
+    """Return the ``.gnmap`` sibling of an nmap ``.xml`` output path."""
+    return os.path.splitext(xml_path)[0] + '.gnmap'
 
 
 def _quarantine_failed_output(output_file):
@@ -2088,6 +2099,12 @@ def _quarantine_failed_output(output_file):
     Returns None when there was nothing to rename or the rename failed — a
     missing output file already fails the gate, so either way the port is
     re-scanned.
+
+    The sibling '.gnmap' is quarantined alongside it, for the same reason and to
+    the same '.failed' suffix.  Leaving it in place would let a port excluded
+    from spoonmap_output.xml still contribute its partial hosts to
+    spoonmap_output.gnmap, so the two artifacts would disagree about what was
+    scanned — and the greppable one would be the optimistic of the two.
     """
     if not os.path.exists(output_file):
         return None
@@ -2096,6 +2113,10 @@ def _quarantine_failed_output(output_file):
         os.replace(output_file, failed_path)
     except OSError:
         return None
+    gnmap = _gnmap_path(output_file)
+    if os.path.exists(gnmap):
+        with contextlib.suppress(OSError):
+            os.replace(gnmap, gnmap + '.failed')
     return failed_path
 
 
@@ -4647,6 +4668,126 @@ def _write_combined_results(output_path, hosts_json, xml_hosts):
         print(_COLOR_RESULT + f'\nResults written to {output_path}/spoonmap_output.xml / .json' + _COLOR_RESET)
 
 
+def _parse_gnmap_line(line):
+    """Split one grepable ``Host:`` line into ``(ip, host_field, port_entries)``.
+
+    Returns None for anything that is not a host line carrying ports: comment
+    lines, and the ``Status: Up`` form a host-discovery pass emits.  Fields are
+    tab-separated, which is what makes the format greppable in the first place.
+    """
+    if not line.startswith('Host: '):
+        return None
+    fields = line.split('\t')
+    host_field = fields[0][len('Host: '):].strip()
+    if not host_field:
+        return None
+    ip = host_field.split()[0]
+    for field in fields[1:]:
+        if field.startswith('Ports: '):
+            entries = [e.strip() for e in field[len('Ports: '):].split(',')]
+            entries = [e for e in entries if e]
+            if entries:
+                return ip, host_field, entries
+            return None
+    return None
+
+
+def _gnmap_port_sort_key(entry):
+    """Order a grepable port entry (``22/open/tcp//ssh///``) by port number."""
+    try:
+        return (0, int(entry.split('/', 1)[0]))
+    except ValueError:
+        return (1, 0)
+
+
+def _aggregate_gnmap(result_dir):
+    """Merge ``*.gnmap`` in *result_dir* into one host line per host.
+
+    Each port is scanned by its own nmap run, so a host open on three ports
+    appears in three files.  Grepable output is one line per host, so the
+    per-port lines are merged rather than concatenated — otherwise anything
+    counting lines would over-count hosts, and the file would disagree with
+    spoonmap_output.xml/.json, which merge the same hosts.
+
+    Returns ``(lines, scanned_ports)``: the merged host lines in IP order, and
+    the set of port stems whose .gnmap was present.
+    """
+    merged = {}         # ip -> [host_field, {entry: None} used as ordered set]
+    scanned_ports = set()
+    try:
+        names = sorted(os.listdir(result_dir))
+    except OSError:
+        return [], scanned_ports
+    for fname in names:
+        if not fname.endswith('.gnmap'):
+            continue
+        scanned_ports.add(fname[:-len('.gnmap')])
+        try:
+            with open(os.path.join(result_dir, fname)) as fh:
+                content = fh.read()
+        except OSError as exc:
+            # One unreadable file must not cost the other ports' hosts.
+            print(_COLOR_ERROR + f'Warning: could not read {fname}: {exc}'
+                  + _COLOR_RESET)
+            continue
+        for line in content.splitlines():
+            parsed = _parse_gnmap_line(line.strip())
+            if parsed is None:
+                continue
+            ip, host_field, entries = parsed
+            if ip not in merged:
+                merged[ip] = [host_field, {}]
+            elif len(host_field) > len(merged[ip][0]):
+                # Prefer the form carrying a hostname over a bare address.
+                merged[ip][0] = host_field
+            for entry in entries:
+                merged[ip][1][entry] = None
+    lines = []
+    for ip in sorted(merged, key=_ip_sort_key):
+        host_field, entries = merged[ip]
+        ordered = sorted(entries, key=_gnmap_port_sort_key)
+        lines.append(f'Host: {host_field}\tPorts: {", ".join(ordered)}')
+    return lines, scanned_ports
+
+
+def _write_gnmap_result(output_path, result_dir):
+    """Write spoonmap_output.gnmap from the per-port .gnmap files.
+
+    Ports whose .xml is present but whose .gnmap is missing are named rather
+    than silently omitted: that is what a scan completed before greppable
+    output existed looks like on resume, and an artifact that quietly covers
+    fewer ports than the run did is a coverage claim the scan never made.
+    """
+    lines, scanned = _aggregate_gnmap(result_dir)
+    try:
+        # Only banner-pass outputs have a .gnmap sibling to be missing.
+        # _scan_extra_sql_ports() writes port{N}_sql.xml into this same
+        # directory with no -oG, so counting it here would warn about a gap
+        # that does not exist.
+        xml_stems = {f[:-len('.xml')] for f in os.listdir(result_dir)
+                     if f.startswith('port') and f.endswith('.xml')
+                     and not f.endswith('_sql.xml')}
+    except OSError:
+        xml_stems = set()
+    missing = sorted(xml_stems - scanned)
+    if not lines and not missing:
+        return
+    body = ('# SpooNMAP aggregated greppable output\n'
+            + ''.join(f'{line}\n' for line in lines)
+            + f'# SpooNMAP done: {len(lines)} hosts\n')
+    if _write_artifact(f'{output_path}/spoonmap_output.gnmap', body):
+        print(_COLOR_RESULT + f'\nGreppable output written to '
+              f'{output_path}/spoonmap_output.gnmap' + _COLOR_RESET)
+    if missing:
+        print(_COLOR_ERROR
+              + f'Warning: {len(missing)} port(s) have nmap XML but no greppable '
+              + 'output and are absent from spoonmap_output.gnmap: '
+              + ', '.join(missing[:5])
+              + (' ...' if len(missing) > 5 else '')
+              + '. Re-run those ports, or use spoonmap_output.xml, which covers them.'
+              + _COLOR_RESET)
+
+
 def _read_config_file(path):
     """Parse *path* as a JSON object, or print a clear diagnostic and exit.
 
@@ -5799,6 +5940,11 @@ def main():  # pragma: no cover -- interactive CLI entry point; orchestrates
                 result_dir = f'{disc}/masscan_results/'
             hosts_json, xml_hosts = _aggregate_result_dir(result_dir, ip_to_hostname)
             _write_combined_results(output_path, hosts_json, xml_hosts)
+
+            # Greppable output only exists for the nmap banner pass; a
+            # masscan-only run has no -oG files to merge.
+            if banner_scan or script_scan:
+                _write_gnmap_result(output_path, result_dir)
 
             _combine_live_hosts(disc, output_path)
 

--- a/tests/test_spoonmap.py
+++ b/tests/test_spoonmap.py
@@ -64,6 +64,11 @@ from spoonmap import (
     _combine_live_hosts,
     _load_config,
     _read_config_file,
+    _aggregate_gnmap,
+    _gnmap_path,
+    _gnmap_port_sort_key,
+    _parse_gnmap_line,
+    _write_gnmap_result,
     _write_artifact,
     _write_combined_results,
     _write_if_changed,
@@ -10830,3 +10835,244 @@ class TestWriteCliTargetFile:
     def test_atomic_leaves_no_temp_file(self, tmp_path):
         _write_cli_target_file(['10.0.0.5'], str(tmp_path))
         assert [p.name for p in tmp_path.iterdir()] == ['cli_targets.txt']
+
+
+# ── greppable (-oG) output ────────────────────────────────────────────────────
+
+class TestGnmapPath:
+    def test_swaps_xml_for_gnmap(self):
+        assert _gnmap_path('/out/nmap_results/port80.xml') == \
+            '/out/nmap_results/port80.gnmap'
+
+    def test_udp_port_filename(self):
+        assert _gnmap_path('/out/portU_161.xml') == '/out/portU_161.gnmap'
+
+
+class TestBannerPassGnmapFlag:
+    """Every banner pass gets its own -oG file; the script pass gets none."""
+
+    def test_tcp_banner_pass_includes_og(self):
+        cmd = _build_nmap_cmd('80', '/in.txt', '/out/port80.xml', '53',
+                              target_scan='External')
+        assert cmd[cmd.index('-oG') + 1] == '/out/port80.gnmap'
+
+    def test_udp_banner_pass_includes_og(self):
+        cmd = _build_nmap_cmd('U:161', '/in.txt', '/out/portU_161.xml', '53',
+                              target_scan='External')
+        assert cmd[cmd.index('-oG') + 1] == '/out/portU_161.gnmap'
+
+    def test_script_pass_has_no_og(self):
+        """A shared -oG across the script pass would duplicate the banner data."""
+        cmd = _build_nmap_cmd('80', '/in.txt', '/out/port80.xml', '53',
+                              script_scan=True, target_scan='External',
+                              script_only=True)
+        assert '-oG' not in cmd
+
+    def test_one_og_file_per_port(self):
+        """Distinct ports must not share an -oG target: concurrent workers
+        appending to one file interleave their writes."""
+        a = _build_nmap_cmd('22', '/in.txt', '/out/port22.xml', '53',
+                            target_scan='External')
+        b = _build_nmap_cmd('80', '/in.txt', '/out/port80.xml', '53',
+                            target_scan='External')
+        assert a[a.index('-oG') + 1] != b[b.index('-oG') + 1]
+        assert '--append-output' not in a
+
+
+class TestParseGnmapLine:
+    def test_host_with_ports(self):
+        ip, host_field, entries = _parse_gnmap_line(
+            'Host: 10.0.0.5 (web01)\tPorts: 22/open/tcp//ssh///'
+            '\tIgnored State: closed (1)')
+        assert ip == '10.0.0.5'
+        assert host_field == '10.0.0.5 (web01)'
+        assert entries == ['22/open/tcp//ssh///']
+
+    def test_multiple_ports_split_on_comma(self):
+        _, _, entries = _parse_gnmap_line(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp//ssh///, 80/open/tcp//http///')
+        assert entries == ['22/open/tcp//ssh///', '80/open/tcp//http///']
+
+    def test_status_up_line_ignored(self):
+        """A host-discovery line carries no ports and is not a scan result."""
+        assert _parse_gnmap_line('Host: 10.0.0.9 ()\tStatus: Up') is None
+
+    def test_comment_line_ignored(self):
+        assert _parse_gnmap_line('# Nmap 7.99 scan initiated') is None
+
+    def test_empty_host_field_ignored(self):
+        assert _parse_gnmap_line('Host: \tPorts: 22/open/tcp//ssh///') is None
+
+    def test_empty_ports_field_ignored(self):
+        assert _parse_gnmap_line('Host: 10.0.0.5 ()\tPorts: ') is None
+
+
+class TestGnmapPortSortKey:
+    def test_orders_numerically_not_lexically(self):
+        entries = ['443/open/tcp///', '80/open/tcp///', '8080/open/tcp///']
+        assert [e.split('/')[0] for e in sorted(entries, key=_gnmap_port_sort_key)] \
+            == ['80', '443', '8080']
+
+    def test_unparseable_entry_sorts_last_without_raising(self):
+        entries = ['garbage', '80/open/tcp///']
+        assert sorted(entries, key=_gnmap_port_sort_key)[0] == '80/open/tcp///'
+
+
+class TestAggregateGnmap:
+    def test_merges_one_line_per_host_across_ports(self, tmp_path):
+        """Each port is a separate nmap run, so a host open on two ports appears
+        in two files; grepable output is one line per host."""
+        (tmp_path / 'port22.gnmap').write_text(
+            'Host: 10.0.0.5 (web01)\tPorts: 22/open/tcp//ssh///\n')
+        (tmp_path / 'port80.gnmap').write_text(
+            'Host: 10.0.0.5 (web01)\tPorts: 80/open/tcp//http///\n')
+        lines, scanned = _aggregate_gnmap(str(tmp_path))
+        assert lines == [
+            'Host: 10.0.0.5 (web01)\tPorts: 22/open/tcp//ssh///, 80/open/tcp//http///']
+        assert scanned == {'port22', 'port80'}
+
+    def test_hosts_sorted_numerically(self, tmp_path):
+        (tmp_path / 'port22.gnmap').write_text(
+            'Host: 10.0.0.200 ()\tPorts: 22/open/tcp///\n'
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        lines, _ = _aggregate_gnmap(str(tmp_path))
+        assert lines[0].startswith('Host: 10.0.0.5')
+
+    def test_duplicate_port_entry_not_repeated(self, tmp_path):
+        (tmp_path / 'port22.gnmap').write_text(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        (tmp_path / 'port22b.gnmap').write_text(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        lines, _ = _aggregate_gnmap(str(tmp_path))
+        assert lines == ['Host: 10.0.0.5 ()\tPorts: 22/open/tcp///']
+
+    def test_hostname_form_preferred_over_bare_address(self, tmp_path):
+        (tmp_path / 'port22.gnmap').write_text(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        (tmp_path / 'port80.gnmap').write_text(
+            'Host: 10.0.0.5 (web01)\tPorts: 80/open/tcp///\n')
+        lines, _ = _aggregate_gnmap(str(tmp_path))
+        assert lines[0].startswith('Host: 10.0.0.5 (web01)')
+
+    def test_non_gnmap_files_ignored(self, tmp_path):
+        (tmp_path / 'port22.xml').write_text('<nmaprun></nmaprun>')
+        (tmp_path / 'port22.gnmap.failed').write_text(
+            'Host: 10.9.9.9 ()\tPorts: 22/open/tcp///\n')
+        lines, scanned = _aggregate_gnmap(str(tmp_path))
+        assert lines == []
+        assert scanned == set()
+
+    def test_missing_directory_returns_empty(self, tmp_path):
+        lines, scanned = _aggregate_gnmap(str(tmp_path / 'nope'))
+        assert (lines, scanned) == ([], set())
+
+    def test_real_file_shape_comments_and_status_skipped(self, tmp_path):
+        """nmap always brackets -oG output with comment lines, and a host with
+        no open ports appears as 'Status: Up'."""
+        (tmp_path / 'port22.gnmap').write_text(
+            '# Nmap 7.99 scan initiated Thu Aug 21 11:00:00 2026 as: nmap -oG\n'
+            'Host: 10.0.0.5 (web01)\tPorts: 22/open/tcp//ssh///\tIgnored State: closed (1)\n'
+            'Host: 10.0.0.9 ()\tStatus: Up\n'
+            '# Nmap done at Thu Aug 21 11:00:04 2026 -- 2 IP addresses\n')
+        lines, _ = _aggregate_gnmap(str(tmp_path))
+        assert lines == [
+            'Host: 10.0.0.5 (web01)\tPorts: 22/open/tcp//ssh///']
+
+    def test_unreadable_file_does_not_lose_other_ports(self, tmp_path, capsys):
+        (tmp_path / 'port22.gnmap').write_text(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        (tmp_path / 'port80.gnmap').mkdir()   # a directory reads as OSError
+        lines, _ = _aggregate_gnmap(str(tmp_path))
+        assert lines == ['Host: 10.0.0.5 ()\tPorts: 22/open/tcp///']
+        assert 'could not read' in capsys.readouterr().out
+
+
+class TestWriteGnmapResult:
+    def _results(self, tmp_path):
+        rd = tmp_path / 'nmap_results'
+        rd.mkdir()
+        return rd
+
+    def test_writes_aggregate_with_header_and_count(self, tmp_path):
+        rd = self._results(tmp_path)
+        (rd / 'port22.gnmap').write_text(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        (rd / 'port22.xml').write_text('<nmaprun></nmaprun>')
+        _write_gnmap_result(str(tmp_path), str(rd))
+        content = (tmp_path / 'spoonmap_output.gnmap').read_text()
+        assert content.startswith('# SpooNMAP aggregated greppable output\n')
+        assert 'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///' in content
+        assert content.endswith('# SpooNMAP done: 1 hosts\n')
+
+    def test_port_with_xml_but_no_gnmap_is_disclosed(self, tmp_path, capsys):
+        """A scan completed before -oG existed must not silently shrink the
+        artifact's coverage."""
+        rd = self._results(tmp_path)
+        (rd / 'port22.gnmap').write_text(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        (rd / 'port22.xml').write_text('<nmaprun></nmaprun>')
+        (rd / 'port443.xml').write_text('<nmaprun></nmaprun>')
+        _write_gnmap_result(str(tmp_path), str(rd))
+        out = capsys.readouterr().out
+        assert 'port443' in out
+        assert '1 port(s)' in out
+
+    def test_sql_xml_not_reported_as_a_gap(self, tmp_path, capsys):
+        """_scan_extra_sql_ports writes port{N}_sql.xml with no -oG."""
+        rd = self._results(tmp_path)
+        (rd / 'port22.gnmap').write_text(
+            'Host: 10.0.0.5 ()\tPorts: 22/open/tcp///\n')
+        (rd / 'port22.xml').write_text('<nmaprun></nmaprun>')
+        (rd / 'port1433_sql.xml').write_text('<nmaprun></nmaprun>')
+        _write_gnmap_result(str(tmp_path), str(rd))
+        assert 'no greppable output' not in capsys.readouterr().out
+
+    def test_many_missing_ports_truncated(self, tmp_path, capsys):
+        rd = self._results(tmp_path)
+        for n in range(7):
+            (rd / f'port{100 + n}.xml').write_text('<nmaprun></nmaprun>')
+        _write_gnmap_result(str(tmp_path), str(rd))
+        out = capsys.readouterr().out
+        assert '7 port(s)' in out
+        assert '...' in out
+
+    def test_nothing_to_write_creates_no_file(self, tmp_path):
+        rd = self._results(tmp_path)
+        _write_gnmap_result(str(tmp_path), str(rd))
+        assert not (tmp_path / 'spoonmap_output.gnmap').exists()
+
+    def test_missing_result_dir_creates_no_file(self, tmp_path):
+        _write_gnmap_result(str(tmp_path), str(tmp_path / 'nope'))
+        assert not (tmp_path / 'spoonmap_output.gnmap').exists()
+
+    def test_gnmap_listed_for_cleanup(self):
+        """--cleanup must remove the new artifact along with the others."""
+        assert 'spoonmap_output.gnmap' in spoonmap._RESULT_FILES
+
+
+class TestQuarantineQuarantinesGnmap:
+    """A failed port's .gnmap must not outlive its quarantined .xml."""
+
+    def test_gnmap_sibling_renamed(self, tmp_path):
+        xml = tmp_path / 'port80.xml'
+        gnmap = tmp_path / 'port80.gnmap'
+        xml.write_text('<nmaprun></nmaprun>')
+        gnmap.write_text('Host: 10.0.0.5 ()\tPorts: 80/open/tcp///\n')
+        _quarantine_failed_output(str(xml))
+        assert not gnmap.exists()
+        assert (tmp_path / 'port80.gnmap.failed').exists()
+
+    def test_quarantined_gnmap_excluded_from_aggregate(self, tmp_path):
+        """The end the rename exists for: a failed port contributes nothing."""
+        xml = tmp_path / 'port80.xml'
+        xml.write_text('<nmaprun></nmaprun>')
+        (tmp_path / 'port80.gnmap').write_text(
+            'Host: 10.9.9.9 ()\tPorts: 80/open/tcp///\n')
+        _quarantine_failed_output(str(xml))
+        lines, _ = _aggregate_gnmap(str(tmp_path))
+        assert lines == []
+
+    def test_absent_gnmap_is_not_an_error(self, tmp_path):
+        xml = tmp_path / 'port80.xml'
+        xml.write_text('<nmaprun></nmaprun>')
+        assert _quarantine_failed_output(str(xml)) == str(xml) + '.failed'


### PR DESCRIPTION
Closes #36. Implements the idea from PR #11 (Feb 2021, @zenfosec), which I closed as unmergeable.

## What this adds

Each port's banner pass writes `nmap_results/portN.gnmap` via `-oG`, and those are merged into `spoonmap_output.gnmap` once the workers join:

```
# SpooNMAP aggregated greppable output
Host: 10.0.0.5 (web01)	Ports: 22/open/tcp//ssh//OpenSSH 8.9p1/, 80/open/tcp//http//nginx 1.18/
Host: 10.0.0.200 ()	Ports: 445/open/tcp//microsoft-ds///
# SpooNMAP done: 2 hosts
```

## Why not #11's approach

#11 pointed every port at a single shared `-oG` file with `--append-output`. That was safe when nmap ran serially. `nmap_scan()` now runs five concurrent workers by default, so five nmap processes would be appending to one file simultaneously and interleaving their writes — producing a plausible-looking but corrupt host list. For a format whose entire purpose is machine consumption, silently corrupt is worse than absent. One file per port gives each a single writer.

## Merged, not concatenated

A host open on three ports is scanned by three separate nmap runs, so it appears in three per-port files. Grepable output is one line per host, so those are merged rather than concatenated. Concatenating would make anything counting lines over-count hosts, and would put this artifact at odds with `spoonmap_output.xml`/`.json`, which merge the same hosts.

Hosts come out in numeric IP order (`_ip_sort_key()`) and port entries in numeric port order, so the file is stable across runs and diffable between scans.

## Two consistency details worth review

**A quarantined port's `.gnmap` is quarantined too.** `_quarantine_failed_output()` renames the sibling `.gnmap` alongside the `.xml`. Without that, a port excluded from `spoonmap_output.xml` for a failed nmap exit would still contribute its partial hosts to `spoonmap_output.gnmap` — the two artifacts would disagree about what was scanned, and the greppable one would be the optimistic of the two. There's a test asserting the quarantined data doesn't reach the aggregate.

**Ports with `.xml` but no `.gnmap` are named, not dropped.** That's what resuming a scan from before this feature looks like. An artifact that quietly covers less than the run did is a coverage claim the scan never made, so it warns and points at `spoonmap_output.xml`. `port{N}_sql.xml` is excluded from that check — `_scan_extra_sql_ports()` writes it with no `-oG`, so it isn't a gap.

## Safety for existing readers

Adding `.gnmap` files to `nmap_results/` doesn't disturb anything: all three call sites that scan that directory filter on an `.xml` extension, and `_parse_result_xml()` returns None for anything else (no warning spam). `spoonmap_output.gnmap` is registered in `_RESULT_FILES`, so `--cleanup` removes it.

Scope is the banner pass only. The NSE script pass writes to its own directory and its results are surfaced as findings, so a `-oG` there would duplicate without adding anything greppable.

## Verification

- **939 passed / 5 skipped / 100% coverage** (gate is 95%), 32 new tests.
- No suppressions added.
- **The parser was checked against real nmap 7.99 `-oG` output, not just fixtures** — confirming the tab-separated field layout, the `Status: Up` line nmap emits *alongside* the ports line for the same host, the trailing `Ignored State` field, and the comment header/footer. The fixtures were then written to match what nmap actually produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
