### PR TITLE
ci: run the test suite on pull requests via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A new push to the same PR supersedes the previous run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: tests (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        # pyproject declares requires-python >=3.8; every claimed version is tested.
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        include:
+          # The tool is developed on macOS, which has its own termios/stty paths.
+          - os: macos-latest
+            python-version: '3.12'
+    steps:
+      - uses: actions/checkout@v4
+
+      # tests/test_nse_integration.py shells out to real nmap against local stub
+      # servers. Without nmap the whole module skips itself, so installing it is
+      # what makes the NSE assertions actually run.
+      - name: Install nmap
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends nmap
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          enable-cache: true
+
+      - name: Check uv.lock is up to date
+        run: uv lock --check
+
+      # Coverage reporting and the 95% floor come from [tool.pytest.ini_options]
+      # in pyproject.toml, so a coverage regression fails this step too.
+      - name: Run tests
+        run: uv run --frozen pytest tests/ -v

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,12 @@ uv run pytest tests/test_spoonmap.py::TestGenerateFindings  # single class
 
 `tests/test_nse_integration.py` binds real local ports and shells out to real `nmap`, so its results depend on the machine. A class names the port it needs with a `required_tcp_port` / `required_udp_port` attribute and `pytest_runtest_setup()` in `tests/conftest.py` skips it if that port is occupied — checked immediately before each test, not at import, because a port free during collection can be taken by the time the test runs (that race produced spurious failures). A skip there always means a port conflict or missing root, never an NSE result; the assertions themselves are unconditional.
 
+CI (`.github/workflows/ci.yml`) runs that same suite on every pull request and on
+pushes to `main`: Python 3.8–3.13 on Ubuntu (with nmap installed, so the NSE
+integration tests run rather than skip) plus Python 3.12 on macOS, and a
+`uv lock --check` step. The 95% coverage floor is enforced by pytest's `addopts`,
+so CI inherits it without restating it.
+
 Pass `--cleanup [dir]` to remove prior scan output non-interactively (reads `output_path` from `config.json` if no directory is given).
 
 ## Architecture

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SpooNMAP
 
+[![CI](https://github.com/trustedsec/spoonmap/actions/workflows/ci.yml/badge.svg)](https://github.com/trustedsec/spoonmap/actions/workflows/ci.yml)
+
 ## Dependencies
 This script is a wrapper for masscan and nmap. nmap handles host discovery and (for smaller scans) port discovery, service banner grabbing, and NSE scripts. Masscan is used for large-scale port discovery where raw speed matters. Install both from your favourite package manager or from source.
 
@@ -443,3 +445,27 @@ On External scans, each externally-exposed sensitive service is additionally vul
 - **IKE/IPsec (U:500)** — [ike-version NSE](https://nmap.org/nsedoc/scripts/ike-version.html) · ike-scan --aggressive for hash capture · hashcat mode 5300 (IKEv1) / 5400 (IKEv2)
 - **IPMI (U:623)** — [US-CERT TA13-207A](https://www.cisa.gov/news-events/alerts/2013/07/26/risks-using-intelligent-platform-management-interface-ipmi) · [hashcat mode 7300](https://hashcat.net/wiki/doku.php?id=hashcat)
 - **VNC (5900/5901)** — [CVE-2006-2369](https://nvd.nist.gov/vuln/detail/CVE-2006-2369) · [vnc-info NSE](https://nmap.org/nsedoc/scripts/vnc-info.html) · [vnc-title NSE](https://nmap.org/nsedoc/scripts/vnc-title.html)
+
+## Development
+
+Run the test suite with [uv](https://docs.astral.sh/uv/):
+
+```bash
+uv run pytest tests/
+uv run pytest tests/test_spoonmap.py::TestGenerateFindings   # single class
+```
+
+Coverage is measured on every run and the suite fails below 95% (see
+`[tool.pytest.ini_options]` in `pyproject.toml`).
+
+`tests/test_nse_integration.py` binds real local ports and shells out to real
+nmap, so it skips itself where nmap is absent, where a port it needs is already
+in use, or (for the `-sU` cases) where the run is not root. A skip there is
+always an environment conflict, never an NSE result.
+
+### Continuous integration
+
+`.github/workflows/ci.yml` runs on every pull request and on pushes to `main`:
+the suite is exercised on Python 3.8–3.13 on Ubuntu plus Python 3.12 on macOS,
+with nmap installed on the Ubuntu jobs so the NSE integration tests actually
+run. It also checks that `uv.lock` is in sync with `pyproject.toml`.


### PR DESCRIPTION
Adds GitHub Actions CI so pull requests get an automated signal instead of relying on a local `pytest` run.

## What runs

`.github/workflows/ci.yml`, on `pull_request` and on pushes to `main`:

- **Python 3.8–3.13 on `ubuntu-latest`** — every version `pyproject.toml` declares via `requires-python = ">=3.8"`. Older versions come from uv's managed interpreters, so no version is skipped just because the runner image lacks it.
- **Python 3.12 on `macos-latest`** — the tool is developed on macOS and has its own `termios`/`stty` handling, so a Linux-only matrix would leave that untested.
- **`uv lock --check`** — catches a `pyproject.toml` change that was never locked.
- **`uv run --frozen pytest tests/ -v`** — the same command used locally.

`nmap` is installed on the Ubuntu jobs. `tests/test_nse_integration.py` skips its entire module when `nmap` is absent, so without that step the NSE assertions would report green without ever executing.

Concurrency is keyed on the PR head ref with `cancel-in-progress`, so a new push supersedes the previous run rather than queueing behind it. `permissions: contents: read` only.

The 95% coverage floor is deliberately **not** restated in the workflow — it already comes from `addopts` in `[tool.pytest.ini_options]`, so a coverage regression fails the test step and there is only one place to change the threshold.

## Verification

Locally, in a clean worktree off `main`:

- `actionlint .github/workflows/ci.yml` → 0 errors
- `uv lock --check` → lock in sync
- `uv run --frozen pytest tests/ -q` → 907 passed, 5 skipped, 99.91% coverage
- `uv run --frozen --python 3.8 pytest tests/ -q` → 907 passed, 5 skipped (confirms the oldest matrix entry resolves and passes)

The 5 skips are the expected environment gates: NSE cases whose local port was occupied, and the `-sU` case that needs root.

## Note on the open PRs

Workflows run from the head branch of a PR, so #37 and #38 will not show checks until they pick up `main` after this merges.

Also worth flagging separately: the push output surfaced a Dependabot alert on this repo (https://github.com/trustedsec/spoonmap/security/dependabot/2) — unrelated to this change, but visible now.

## Docs

- README: CI badge and a new `## Development` section covering how to run the suite, the coverage floor, and why an NSE skip is an environment conflict rather than a failure.
- `CLAUDE.md`: a short paragraph describing what CI covers.
